### PR TITLE
Add 'learn more' button.

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -31,6 +31,15 @@
     <canvas id="glcanvas" tabindex='1'></canvas>
     <!-- Minified and statically hosted version of https://github.com/not-fl3/macroquad/blob/master/js/mq_js_bundle.js -->
     <script src="mq_js_bundle.js"></script>
+    <script>
+        miniquad_add_plugin({
+            register_plugin(importObject) {
+                importObject.env.open_website = () => {
+                    window.open("https://github.com/toolness/neural-net-fun");
+                };
+            }
+        });
+    </script>
     <script>load("neural-net-fun.wasm");</script> <!-- Your compiled WASM binary -->
 </body>
 </html>


### PR DESCRIPTION
This adds a learn more button in the WASM build, but it's not great because the mouse events get messed up and when the user returns to the app it thinks the mouse is still down.